### PR TITLE
Boilerplate: fixed currentTable nullptr dereference

### DIFF
--- a/cmd/boilerplate/main.go
+++ b/cmd/boilerplate/main.go
@@ -191,10 +191,10 @@ func query(w http.ResponseWriter, r *http.Request) {
 	var currentTable *Table
 	for tables.Next() {
 		if tables.TableChanged() || currentTable == nil {
-			response.Tables = append(response.Tables, *currentTable)
 			currentTable = &Table{
 				Metadata: tables.TableMetadata().String(),
 			}
+			response.Tables = append(response.Tables, *currentTable)
 		}
 		currentTable.Records = append(currentTable.Records, tables.Record().String())
 	}


### PR DESCRIPTION
Seems like the appending and assigning lines are swapped here, since we check if the `currentTable` is nil and dereference it if so.